### PR TITLE
Fixed error in deploydocs()

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -47,4 +47,4 @@ makedocs(
     ],
 )
 
-deploydocs(;repo = "github.com/bancaditalia/BeforeIT.jl.git", devbranch = "main", target = "build", branch="gh-pages")
+deploydocs(;repo = "github.com/arnauqb/BeforeIT.jl.git", devbranch = "main", target = "build", branch="gh-pages")

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -47,4 +47,4 @@ makedocs(
     ],
 )
 
-deploydocs(;repo = "github.com/arnauqb/BeforeIT.jl.git", devbranch = "main", target = "build", branch="gh-pages")
+deploydocs(;repo = "github.com/bancaditalia/BeforeIT.jl.git", devbranch = "main", target = "build", branch="gh-pages")

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -47,4 +47,4 @@ makedocs(
     ],
 )
 
-deploydocs(;repo = "github.com/bancaditalia/BeforeIT.jl.git", devbranch = "main", target = "gh-pages")
+deploydocs(;repo = "github.com/arnauqb/BeforeIT.jl.git", devbranch = "main", target = "build", branch="gh-pages")


### PR DESCRIPTION
According to this:

https://documenter.juliadocs.org/stable/lib/public/#Documenter.deploydocs

I think the `deploydocs` in `docs/make.jl` function is being called incorrectly. `target` refers to the build directory, not the GH branch.

PS: GH actions seems to be down at the moment.