### PR TITLE
Use `matlab_round` instead of `round` to fix precompilation issues

### DIFF
--- a/src/BeforeIT.jl
+++ b/src/BeforeIT.jl
@@ -2,7 +2,7 @@ module BeforeIT
 
 using Random
 using StatsBase
-import Base: round, length
+import Base: length
 
 # definition of agents
 include("model_init/agents.jl")

--- a/src/model_init/init_firms.jl
+++ b/src/model_init/init_firms.jl
@@ -32,7 +32,7 @@ function init_firms(parameters, initial_conditions; typeInt = Int64, typeFloat =
     D_I = initial_conditions["D_I"]
     L_I = initial_conditions["L_I"]
     omega = initial_conditions["omega"]
-    N_s = BeforeIT.round.(Int, initial_conditions["N_s"])
+    N_s = round.(Int, initial_conditions["N_s"])
     r_bar = initial_conditions["r_bar"]
     D_H = initial_conditions["D_H"]
     K_H = initial_conditions["K_H"]

--- a/src/utils/_calibration_steady_state.jl
+++ b/src/utils/_calibration_steady_state.jl
@@ -148,15 +148,15 @@ function get_params_and_initial_conditions_steady_state(
     disposable_income =
         sum(wages) + mixed_income + property_income + social_benefits + other_net_transfers -
         household_social_contributions - household_income_tax - capital_taxes
-    unemployed = BeforeIT.round(unemployment_rate_quarterly * sum(employees))
+    unemployed = matlab_round(unemployment_rate_quarterly * sum(employees))
     inactive = population - sum(max.(max.(1, firms), employees)) - unemployed - sum(max.(1, firms)) - 1
 
 
     # Scale number of firms and employees
-    firms = max.(1, BeforeIT.round.(scale * firms))
-    employees = max.(firms, BeforeIT.round.(scale * employees))
-    inactive = max.(1, BeforeIT.round.(scale * inactive))
-    unemployed = max.(1, BeforeIT.round.(scale * unemployed))
+    firms = max.(1, matlab_round.(scale * firms))
+    employees = max.(firms, matlab_round.(scale * employees))
+    inactive = max.(1, matlab_round.(scale * inactive))
+    unemployed = max.(1, matlab_round.(scale * unemployed))
 
 
     # Sector parameters
@@ -187,8 +187,8 @@ function get_params_and_initial_conditions_steady_state(
     S = G
     H_act = sum(employees) + unemployed + sum(firms) + 1
     H_inact = inactive
-    J = BeforeIT.round(sum(firms) / 4)
-    L = BeforeIT.round(sum(firms) / 2)
+    J = matlab_round(sum(firms) / 4)
+    L = matlab_round(sum(firms) / 2)
     mu = timescale * firm_interest / firm_debt_quarterly - r_bar
     tau_INC =
         (household_income_tax + capital_taxes) /

--- a/src/utils/calibration.jl
+++ b/src/utils/calibration.jl
@@ -12,7 +12,7 @@ date2num(d::Dates.DateTime) = Dates.value(d - MATLAB_EPOCH) / (1000 * 60 * 60 * 
 
 # imverse function of the above
 const MATLAB_EPOCH = Dates.DateTime(-1, 12, 31)
-num2date(n::Number) = MATLAB_EPOCH + Dates.Millisecond(matlab_round(Int64, n * 1000 * 60 * 60 * 24))
+num2date(n::Number) = MATLAB_EPOCH + Dates.Millisecond(round(Int64, n * 1000 * 60 * 60 * 24))
 
 
 function get_params_and_initial_conditions(calibration_object, calibration_date; scale = 0.001)

--- a/src/utils/calibration.jl
+++ b/src/utils/calibration.jl
@@ -12,7 +12,7 @@ date2num(d::Dates.DateTime) = Dates.value(d - MATLAB_EPOCH) / (1000 * 60 * 60 * 
 
 # imverse function of the above
 const MATLAB_EPOCH = Dates.DateTime(-1, 12, 31)
-num2date(n::Number) = MATLAB_EPOCH + Dates.Millisecond(BeforeIT.round(Int64, n * 1000 * 60 * 60 * 24))
+num2date(n::Number) = MATLAB_EPOCH + Dates.Millisecond(matlab_round(Int64, n * 1000 * 60 * 60 * 24))
 
 
 function get_params_and_initial_conditions(calibration_object, calibration_date; scale = 0.001)
@@ -149,15 +149,15 @@ function get_params_and_initial_conditions(calibration_object, calibration_date;
     disposable_income =
         sum(wages) + mixed_income + property_income + social_benefits + other_net_transfers -
         household_social_contributions - household_income_tax - capital_taxes
-    unemployed = BeforeIT.round(unemployment_rate_quarterly * sum(employees))
+    unemployed = matlab_round(unemployment_rate_quarterly * sum(employees))
     inactive = population - sum(max.(max.(1, firms), employees)) - unemployed - sum(max.(1, firms)) - 1
 
 
     # Scale number of firms and employees
-    firms = max.(1, BeforeIT.round.(scale * firms))
-    employees = max.(firms, BeforeIT.round.(scale * employees))
-    inactive = max.(1, BeforeIT.round.(scale * inactive))
-    unemployed = max.(1, BeforeIT.round.(scale * unemployed))
+    firms = max.(1, matlab_round.(scale * firms))
+    employees = max.(firms, matlab_round.(scale * employees))
+    inactive = max.(1, matlab_round.(scale * inactive))
+    unemployed = max.(1, matlab_round.(scale * unemployed))
 
 
     # Sector parameters
@@ -188,8 +188,8 @@ function get_params_and_initial_conditions(calibration_object, calibration_date;
     S = G
     H_act = sum(employees) + unemployed + sum(firms) + 1
     H_inact = inactive
-    J = BeforeIT.round(sum(firms) / 4)
-    L = BeforeIT.round(sum(firms) / 2)
+    J = matlab_round(sum(firms) / 4)
+    L = matlab_round(sum(firms) / 2)
     mu = timescale * firm_interest / firm_debt_quarterly - r_bar
     tau_INC =
         (household_income_tax + capital_taxes) /

--- a/src/utils/positive.jl
+++ b/src/utils/positive.jl
@@ -77,7 +77,7 @@ function neg(number::T) where {T <: Number}
 end
 
 # like in the original code
-function round(x)
+function matlab_round(x)
     return Base.round(x, RoundNearestTiesUp)
 end
 


### PR DESCRIPTION
Precompilation failed before this:

```julia
julia> using BeforeIT
Precompiling BeforeIT...
Info Given BeforeIT was explicitly requested, output will be shown live 
WARNING: Method definition round(Any) in module Base at rounding.jl:472 overwritten in module BeforeIT at /home/bob/.julia/dev/BeforeIT/src/utils/positive.jl:80.
ERROR: Method overwriting is not permitted during Module precompilation. Use `__precompile__(false)` to opt-out of precompilation.
  ? BeforeIT
[ Info: Precompiling BeforeIT [ca9fcad7-41d0-4f76-b1e5-366c28bce52e] 
WARNING: Method definition round(Any) in module Base at rounding.jl:472 overwritten in module BeforeIT at /home/bob/.julia/dev/BeforeIT/src/utils/positive.jl:80.
ERROR: Method overwriting is not permitted during Module precompilation. Use `__precompile__(false)` to opt-out of precompilation.
┌ Info: Skipping precompilation due to precompilable error. Importing BeforeIT [ca9fcad7-41d0-4f76-b1e5-366c28bce52e].
└   exception = Error when precompiling module, potentially caused by a __precompile__(false) declaration in the module.
```

p.s. Very Cool Project!!!