### PR TITLE
Update benchmark by returning outputs

### DIFF
--- a/examples/benchmark_w_matlab.jl
+++ b/examples/benchmark_w_matlab.jl
@@ -1,7 +1,9 @@
 
 # # Comparing the performance of the Julia and MATLAB implementations
 
-# We can compare the performance of the Julia and MATLAB implementations by running the same model for the same number of epochs and measuring the time taken.
+# We can compare the performance of the Julia and MATLAB implementations
+# by running the same model for the same number of epochs and measuring
+# the time taken.
 
 using BeforeIT, Plots, Statistics
 
@@ -9,8 +11,7 @@ parameters = BeforeIT.AUSTRIA2010Q1.parameters
 initial_conditions = BeforeIT.AUSTRIA2010Q1.initial_conditions
 T = 12*2 
 
-# We will run the model without any output to avoid the overhead of printing the results.
-function run_no_output(;multi_threading = false)
+function run(; multi_threading = false)
     model = BeforeIT.init_model(parameters, initial_conditions, T)
     data = BeforeIT.init_data(model);
     
@@ -18,11 +19,12 @@ function run_no_output(;multi_threading = false)
         BeforeIT.one_epoch!(model; multi_threading = multi_threading)
         BeforeIT.update_data!(data, model)
     end
+    return model, data
 end
 
-# we run the code to compile it fist
-@time run_no_output() 
-@time run_no_output(;multi_threading = true) 
+# we run the code to compile it first
+@time run();
+@time run(;multi_threading = true);
 
 # time taken by the MATLAB code, computed independently on an Apple M1 chip
 matlab_times = [3.1919, 3.2454, 3.1501, 3.1074, 3.1551]
@@ -34,15 +36,14 @@ n_runs = 5
 
 julia_times_1_thread = zeros(n_runs)   
 for i in 1:n_runs
-    julia_times_1_thread[i] = @elapsed run_no_output()
+    julia_times_1_thread[i] = @elapsed run();
 end
 julia_time_1_thread = mean(julia_times_1_thread)
 julia_time_1_thread_std = std(julia_times_1_thread)
 
-
 julia_times_multi_thread = zeros(n_runs)
 for i in 1:5
-    julia_times_multi_thread[i] =  @elapsed run_no_output(multi_threading = true)
+    julia_times_multi_thread[i] =  @elapsed run(multi_threading = true);
 end
 julia_time_multi_thread = mean(julia_times_multi_thread)
 julia_time_multi_thread_std = std(julia_times_multi_thread)
@@ -51,13 +52,15 @@ julia_time_multi_thread_std = std(julia_times_multi_thread)
 n_threads = Threads.nthreads()
 
 theme(:default, bg = :white)
+
 # bar chart of the time taken vs the time taken by the MATLAB code, also plot the stds as error bars
 # make a white background with no grid
 bar(["MATLAB", "Julia, 1 thread", "Julia, $n_threads threads"], [matlab_time, julia_time_1_thread, julia_time_multi_thread], 
 yerr = [matlab_time_std, julia_time_1_thread_std, julia_time_multi_thread_std],
 legend = false, dpi=300, size=(400, 300), grid = false, ylabel = "Time for one simulation (s)")
 
-# the Julia implementation is faster than the MATLAB implementation, and the multi-threaded version is faster than the single-threaded version.
+# the Julia implementation is faster than the MATLAB implementation, and the multi-threaded version is
+# faster than the single-threaded version.
 
 # increase
 


### PR DESCRIPTION
A smart-enough compiler could have optimized the function away previously, so it is better to return values (but then not printing them by adding `;`)