### PR TITLE
refactor: one_epoch! -> run_one_epoch!

### DIFF
--- a/examples/basic_example.jl
+++ b/examples/basic_example.jl
@@ -34,7 +34,7 @@ data = Bit.init_data(model);
 
 for t in 1:T
     println(t)
-    Bit.one_epoch!(model; multi_threading = true)
+    Bit.run_one_epoch!(model; multi_threading = true)
     Bit.update_data!(data, model)
 end
 

--- a/examples/benchmark_w_matlab.jl
+++ b/examples/benchmark_w_matlab.jl
@@ -12,7 +12,7 @@ function run(parameters, initial_conditions, T; multi_threading = false)
     data = BeforeIT.init_data(model);
     
     for _ in 1:T
-        BeforeIT.one_epoch!(model; multi_threading = multi_threading)
+        BeforeIT.run_one_epoch!(model; multi_threading = multi_threading)
         BeforeIT.update_data!(data, model)
     end
     return model, data

--- a/main.jl
+++ b/main.jl
@@ -10,7 +10,7 @@ data = BeforeIT.init_data(model)
 
 for t in 1:T
     println("Epoch: ", t)
-    BeforeIT.one_epoch!(model; multi_threading = true)
+    BeforeIT.run_one_epoch!(model; multi_threading = true)
     BeforeIT.update_data!(data, model)
 end
 

--- a/src/one_epoch.jl
+++ b/src/one_epoch.jl
@@ -1,7 +1,7 @@
 
 
 """
-    one_epoch!(model; multi_threading = false)
+    run_one_epoch!(model; multi_threading = false)
 
 This function simulates a single epoch the economic model, updating various components of the model based 
 the interactions between different economic agents. It accepts a `model` object, which encapsulates the state for the
@@ -17,7 +17,7 @@ Key operations performed include:
 
 The function updates the model in-place and does not return any value.
 """
-function one_epoch!(model; multi_threading = false, shock = NoShock())
+function run_one_epoch!(model; multi_threading = false, shock = NoShock())
 
     gov = model.gov # government
     cb = model.cb # central bank

--- a/src/one_simulation.jl
+++ b/src/one_simulation.jl
@@ -12,7 +12,7 @@ The simulation runs for a number of epochs specified by `model.prop.T`.
 
 # Details
 The function initializes the data using `BeforeIT.init_data(model)`, then iteratively updates the model and data
-for each epoch using `BeforeIT.one_epoch!(model)` and `BeforeIT.update_data!(data, model)` respectively.
+for each epoch using `BeforeIT.run_one_epoch!(model)` and `BeforeIT.update_data!(data, model)` respectively.
 
 # Example
 ```julia
@@ -26,7 +26,7 @@ function run_one_sim!(model; multi_threading = false, shock = NoShock())
     T = model.prop.T
 
     for _ in 1:T
-        BeforeIT.one_epoch!(model; multi_threading = multi_threading, shock = shock)
+        BeforeIT.run_one_epoch!(model; multi_threading = multi_threading, shock = shock)
         BeforeIT.update_data!(data, model)
     end
 

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -8,7 +8,7 @@ using PrecompileTools
     @compile_workload let
         model = BeforeIT.init_model(parameters, initial_conditions, T)
 	data = BeforeIT.init_data(model);
-	BeforeIT.one_epoch!(model)
+	BeforeIT.run_one_epoch!(model)
 	BeforeIT.update_data!(data, model)
     end
 end

--- a/src/utils/data.jl
+++ b/src/utils/data.jl
@@ -146,7 +146,7 @@ Update the data `d` with the model `m`.
 
 ```julia
 data = BeforeIT.init_data(model)
-one_epoch!(model)
+run_one_epoch!(model)
 BeforeIT.update_data!(data, model)
 ```
 """

--- a/test/accounting_identities.jl
+++ b/test/accounting_identities.jl
@@ -12,7 +12,7 @@ using Test
     data = BeforeIT.init_data(model)
 
     for t in 1:T
-        BeforeIT.one_epoch!(model; multi_threading = false)
+        BeforeIT.run_one_epoch!(model; multi_threading = false)
         BeforeIT.update_data!(data, model)
     end
 

--- a/test/deterministic/deterministic_ouput_t1_t5.jl
+++ b/test/deterministic/deterministic_ouput_t1_t5.jl
@@ -7,7 +7,7 @@
     model = BeforeIT.init_model(parameters, initial_conditions, T)
     data = BeforeIT.init_data(model)
 
-    BeforeIT.one_epoch!(model; multi_threading = false)
+    BeforeIT.run_one_epoch!(model; multi_threading = false)
     BeforeIT.update_data!(data, model)
 
     # import results from matlab run
@@ -33,7 +33,7 @@
     model = BeforeIT.init_model(parameters, initial_conditions, T)
     data = BeforeIT.init_data(model)
     for t in 1:T
-        BeforeIT.one_epoch!(model; multi_threading = false)
+        BeforeIT.run_one_epoch!(model; multi_threading = false)
         BeforeIT.update_data!(data, model)
     end
 

--- a/test/deterministic/one_run_deterministic.jl
+++ b/test/deterministic/one_run_deterministic.jl
@@ -14,7 +14,7 @@
     model = BeforeIT.init_model(parameters1, initial_conditions1, T;)
     data = BeforeIT.init_data(model)
     for t in 1:(T - 1)
-        BeforeIT.one_epoch!(model; multi_threading = false)
+        BeforeIT.run_one_epoch!(model; multi_threading = false)
         BeforeIT.update_data!(data, model)
     end
 
@@ -23,7 +23,7 @@
     data2 = BeforeIT.init_data(model2)
 
     for t in 1:(T - 1)
-        BeforeIT.one_epoch!(model2; multi_threading = false)
+        BeforeIT.run_one_epoch!(model2; multi_threading = false)
         BeforeIT.update_data!(data2, model2)
     end
 

--- a/test/steady_state.jl
+++ b/test/steady_state.jl
@@ -10,7 +10,7 @@ data = BeforeIT.init_data(model)
 
 for t in 1:T
     println(t)
-    BeforeIT.one_epoch!(model; multi_threading = false)
+    BeforeIT.run_one_epoch!(model; multi_threading = false)
     BeforeIT.update_data!(data, model)
 end
 


### PR DESCRIPTION
To improve coherence I refactor the command `one_epoch!` to `run_one_epoch!`