### PR TITLE
examples: add basic inheritance examples and related fixes

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -28,6 +28,7 @@ Literate.markdown(joinpath(indir, "get_parameters_and_initial_conditions.jl"), o
 Literate.markdown(joinpath(indir, "multithreading_speedup.jl"), outdir; credit = false)
 Literate.markdown(joinpath(indir, "scenario_analysis_via_overload.jl"), outdir; credit = false)
 Literate.markdown(joinpath(indir, "change_expectations.jl"), outdir; credit = false)
+Literate.markdown(joinpath(indir, "basic_inheritance.jl"), outdir; credit = false)
 
 
 @info "Building Documentation"
@@ -38,6 +39,7 @@ makedocs(
         "Home" => "index.md",
         "Essentials" => "examples/basic_example.md",
         "Shocked simulations" => "examples/scenario_analysis_via_shock.md",
+        "Essential model extension" => "examples/basic_inheritance.md",
         "Shocked simulations (advanced)" => "examples/scenario_analysis_via_overload.md",
         "Experimentations (advanced)" => "examples/change_expectations.md",
         "Multithreading within the model" => "examples/multithreading_speedup.md",

--- a/examples/basic_inheritance.jl
+++ b/examples/basic_inheritance.jl
@@ -1,0 +1,53 @@
+# # Essential extension of BeforeIT using macros and mltiple dispatch
+import BeforeIT as Bit
+using Plots
+
+# define a new central bank object with one extra attribute
+mutable struct NewCentralBank <: Bit.AbstractCentralBank
+    Bit.@centralBank 
+    fixed_rate::Float64 
+end
+
+# change the default central bank behaviour for the new type
+function Bit.central_bank_rate(cb::NewCentralBank, model::Bit.AbstractModel)
+    return cb.fixed_rate
+end
+
+p, ic = Bit.AUSTRIA2010Q1.parameters, Bit.AUSTRIA2010Q1.initial_conditions
+T = 20
+
+# initialise all agent types using the corresponding functions
+properties = Bit.init_properties(p, T)
+firms, _ = Bit.init_firms(p, ic)
+w_act, w_inact, V_i_new, _, _ = Bit.init_workers(p, ic, firms)
+firms.V_i = V_i_new
+bank, _ = Bit.init_bank(p, ic, firms)
+government, _ = Bit.init_government(p, ic)
+rotw, _ = Bit.init_rotw(p, ic)
+agg, _ = Bit.init_aggregates(p, ic, T)
+
+# initialise the custom central bank
+standard_central_bank, args = Bit.init_central_bank(p, ic)
+newcentral_bank = NewCentralBank(args..., 0.02)
+
+# initialise a new model using the new central bank as well as a standard model
+standard_model = Bit.Model(w_act, w_inact, firms, bank, standard_central_bank,
+government, rotw, agg, properties)
+
+new_model = Bit.Model(w_act, w_inact, firms, bank, newcentral_bank,
+government, rotw, agg, properties)
+
+
+# adjust accounting aften initialisation
+Bit.update_variables_with_totals!(standard_model)
+Bit.update_variables_with_totals!(new_model)
+
+
+# run a simulation with the new model
+data_vec_standard = Bit.ensemblerun(standard_model, 4);
+data_vec_new = Bit.ensemblerun(new_model, 4);
+
+
+# plot the results
+ps = Bit.plot_data_vectors([data_vec_standard, data_vec_new], quantities = [:euribor, :gdp_deflator])
+plot(ps..., layout = (1, 2), size = (600, 300))

--- a/src/agent_actions/central_bank.jl
+++ b/src/agent_actions/central_bank.jl
@@ -11,7 +11,7 @@ Update the base interest rate set by the central bank according to the Taylor ru
 # Returns
 - `r_bar`: The updated base interest rate
 """
-function central_bank_rate(cb::AbstractCentralBank, model::Model)
+function central_bank_rate(cb::AbstractCentralBank, model::AbstractModel)
     # unpack arguments
     gamma_EA = model.rotw.gamma_EA
     pi_EA = model.rotw.pi_EA

--- a/src/agent_actions/firms.jl
+++ b/src/agent_actions/firms.jl
@@ -194,7 +194,7 @@ where:
 - `out_taxes_capital = tau_K_i * P_i * Y_i`
 - `out_loans = r * (L_i + pos(-D_i))`
 """
-function firms_profits(firms::AbstractFirms, model::Model)
+function firms_profits(firms::AbstractFirms, model::AbstractModel)
 
     # unpack variables not related to firms
     P_bar_HH = model.agg.P_bar_HH

--- a/src/agent_actions/government.jl
+++ b/src/agent_actions/government.jl
@@ -43,7 +43,7 @@ imports.
 # Returns
 - `Y_G`: government revenues
 """
-function gov_revenues(model::Model)
+function gov_revenues(model::AbstractModel)
     # unpack objects
     w_act, w_inact, firms, bank, rotw = model.w_act, model.w_inact, model.firms, model.bank, model.rotw
     prop = model.prop

--- a/src/model_init/init.jl
+++ b/src/model_init/init.jl
@@ -15,7 +15,7 @@ Parameters:
 - typeFloat: (optional, default: Float64): The data type to be used for floating-point values.
 
 Returns:
-- model::Model: The initialized model.
+- model::AbstractModel: The initialized model.
 
 """
 function init_model(parameters::Dict{String, Any}, initial_conditions::Dict{String, Any}, T, typeInt::DataType = Int64, typeFloat::DataType = Float64)
@@ -56,19 +56,19 @@ function init_model(parameters::Dict{String, Any}, initial_conditions::Dict{Stri
 end
 
 """
-    update_variables_with_totals!(model::Model)
+    update_variables_with_totals!(model::AbstractModel)
 
 Update the variables in the given `model` with some global quantities obtained from all agents.
 This is the last step in the initialization process and it must be performed after all agents have been initialized.
 
 # Arguments
-- `model::Model`: The model object to update.
+- `model::AbstractModel`: The model object to update.
 
 # Returns
 - Nothing
 
 """
-function update_variables_with_totals!(model::Model)
+function update_variables_with_totals!(model::AbstractModel)
 
     # obtain total income by summing contributions from firm owners, workers and bank owner
     tot_Y_h = sum(model.firms.Y_h) + sum(model.w_act.Y_h) + sum(model.w_inact.Y_h) + model.bank.Y_h

--- a/src/one_simulation.jl
+++ b/src/one_simulation.jl
@@ -5,7 +5,7 @@ Run a single simulation based on the provided `model`.
 The simulation runs for a number of epochs specified by `model.prop.T`.
 
 # Arguments
-- `model::Model`: The model configuration used for the simulation.
+- `model::AbstractModel`: The model configuration used for the simulation.
 
 # Returns
 - `data::Data`: The data collected during the simulation.


### PR DESCRIPTION
I added a simple script to show how the package can be extended using the macros and multiple dispatch. I had to fix a few minor issues to make this work.

This example can greatly help to guide the integration of #54 in the package