### PR TITLE
Fix precompilation error by removing unnecessary reexport of `Base.ro…

### DIFF
--- a/src/utils/positive.jl
+++ b/src/utils/positive.jl
@@ -1,4 +1,4 @@
-export pos, neg, matlab_round
+
 """
     pos(vector) -> vector
 
@@ -98,7 +98,3 @@ end
 function matlab_round(x)
     return Base.round(x, RoundNearestTiesUp)
 end
-
-# function round.(x)
-#     return Base.round.(x + SMALL_FLOAT)
-# end    

--- a/src/utils/positive.jl
+++ b/src/utils/positive.jl
@@ -1,4 +1,4 @@
-export pos, neg, round
+export pos, neg, matlab_round
 """
     pos(vector) -> vector
 


### PR DESCRIPTION
…und`

Precompilation failed due to reexporting `Base.round`, which is not needed. The intended export is likely `matlab_round`.