### PR TITLE
New Object-oriented version of agents for flexibility

### DIFF
--- a/src/BeforeIT.jl
+++ b/src/BeforeIT.jl
@@ -73,6 +73,7 @@ include("utils/dmtest.jl")
 include("utils/mztest.jl")
 include("utils/varx.jl")
 include("utils/sampler.jl")
+include("utils/modify.jl")
 include("utils/misc.jl")
 
 # calibration

--- a/src/model_init/agents.jl
+++ b/src/model_init/agents.jl
@@ -27,6 +27,8 @@ For all fields the entry at index `i` corresponds to the `i`th worker.
 - `I_h`: Realised investment
 """
 Bit.@object struct Workers(Object) <: AbstractWorkers
+    lastid::Base.RefValue{Int}
+    id_to_index::Dict{Int, Int}
     Y_h::Vector{Bit.typeFloat}
     D_h::Vector{Bit.typeFloat}
     K_h::Vector{Bit.typeFloat}
@@ -92,6 +94,8 @@ For all fields the entry at index `i` corresponds to the `i`th firm.
 - `D_h`: Deposits of the owner of the firms
 """
 Bit.@object struct Firms(Object) <: AbstractFirms
+    lastid::Base.RefValue{Int}
+    id_to_index::Dict{Int, Int}
     G_i::Vector{Bit.typeInt}
     alpha_bar_i::Vector{Bit.typeFloat}
     beta_i::Vector{Bit.typeFloat}

--- a/src/model_init/init_firms.jl
+++ b/src/model_init/init_firms.jl
@@ -116,7 +116,10 @@ function Firms(parameters, initial_conditions)
     N_d_i = zeros(typeInt, I)
     Pi_e_i = zeros(typeFloat, I)
 
+    id_to_index = Dict{Int, Int}(id => id for id in 1:I)
+    lastid = Ref(I)
     return Firms(
+        lastid, id_to_index,
         G_i, alpha_bar_i, beta_i, kappa_i, w_i, w_bar_i, delta_i, tau_Y_i, tau_K_i, N_i, Y_i, Q_i, Q_d_i,
         P_i, S_i, K_i, M_i, L_i, pi_bar_i, D_i, Pi_i, V_i, I_i, E_i, P_bar_i, P_CF_i, DS_i, DM_i, DL_i,
         DL_d_i, K_e_i, L_e_i, Q_s_i, I_d_i, DM_d_i, N_d_i, Pi_e_i, Y_h, C_d_h, I_d_h, C_h, I_h, K_h, D_h

--- a/src/model_init/init_workers.jl
+++ b/src/model_init/init_workers.jl
@@ -42,7 +42,9 @@ function Workers(parameters, initial_conditions)
     I_h = zeros(typeFloat, H_W)
 
     # active workers (both employed and unemployed)
-    workers_act = Workers(Y_h, D_h, K_h, w_h, O_h, C_d_h, I_d_h, C_h, I_h)
+    id_to_index = Dict{Int, Int}(id => id for id in 1:H_W)
+    lastid = Ref(H_W)
+    workers_act = Workers(lastid, id_to_index, Y_h, D_h, K_h, w_h, O_h, C_d_h, I_d_h, C_h, I_h)
 
     # inactive workers
     Y_h = zeros(typeFloat, H_inact)
@@ -59,7 +61,9 @@ function Workers(parameters, initial_conditions)
     C_h = zeros(typeFloat, H_inact)
     I_h = zeros(typeFloat, H_inact)
 
-    workers_inact = Workers(Y_h, D_h, K_h, w_h_inact, O_h_inact, C_d_h, I_d_h, C_h, I_h)
+    id_to_index = Dict{Int, Int}(id => id for id in 1:H_inact)
+    lastid = Ref(H_inact)
+    workers_inact = Workers(lastid, id_to_index, Y_h, D_h, K_h, w_h_inact, O_h_inact, C_d_h, I_d_h, C_h, I_h)
 
     return workers_act, workers_inact
 end

--- a/src/utils/modify.jl
+++ b/src/utils/modify.jl
@@ -1,0 +1,64 @@
+
+Base.delete!(structvec::Union{AbstractFirms, AbstractWorkers}, id::Integer) = _delete!(structvec, id)
+function _delete!(structvec, id)
+	i = structvec.id_to_index[id]
+	for fieldn in fieldnames(typeof(structvec))[3:end]
+		vecfield = getfield(structvec, fieldn)
+		vecfield[i], vecfield[end] = vecfield[end], vecfield[i]
+		pop!(vecfield)
+	end
+	delete!(structvec.id_to_index, id)
+	id != structvec.lastid[] && (structvec.id_to_index[structvec.lastid[]] = i)
+	return structvec
+end
+
+Base.push!(structvec::Union{AbstractFirms, AbstractWorkers}, t::NamedTuple) = _push!(structvec, t)
+function _push!(structvec, t)
+	fieldnames(typeof(structvec))[3:end] == keys(t) || error("The tuple fields do not match the container fields")
+	for fieldn in keys(t)
+		vecfield = getfield(structvec, fieldn)
+		tfield = getfield(t, fieldn)
+		push!(vecfield, tfield)
+	end
+	structvec.lastid[] += 1
+	len = length(getfield(structvec, first(keys(t))))
+	structvec.id_to_index[structvec.lastid[]] = len
+	return structvec
+end
+
+struct Worker{S}
+	id::Int
+	structvec::S
+end
+Base.getindex(structvec::AbstractWorkers, id::Integer) = Worker(id, structvec)
+function Base.getproperty(w::Worker, name::Symbol)
+	id, structvec = getfield(w, :id), getfield(w, :structvec)
+	getfield(structvec, name)[structvec.id_to_index[id]]
+end
+function Base.setproperty!(w::Worker, name::Symbol, x)
+	id, structvec = getfield(w, :id), getfield(w, :structvec)
+	setindex!(getfield(structvec, name), x, structvec.id_to_index[id])
+end
+
+struct Firm{S}
+	id::Int
+	structvec::S
+end
+Base.getindex(structvec::AbstractFirms, id::Integer) = Firm(id, structvec)
+function Base.getproperty(f::Firm, name::Symbol)
+	id, structvec = getfield(f, :id), getfield(f, :structvec)
+	getfield(structvec, name)[structvec.id_to_index[id]]
+end
+function Base.setproperty!(f::Firm, name::Symbol, x)
+	id, structvec = getfield(f, :id), getfield(f, :structvec)
+	setindex!(getfield(structvec, name), x, structvec.id_to_index[id])
+end
+
+function Base.show(io::IO, x::Union{Firm, Worker})
+	id, structvec = getfield(x, :id), getfield(x, :structvec)
+	i = structvec.id_to_index[id]
+	T = typeof(x)
+	fields = NamedTuple(y => getfield(structvec, y)[i] for y in fieldnames(typeof(structvec))[3:end])
+	fields = merge((id=id, ), fields)
+	println("$(nameof(T))$fields")
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,6 +10,7 @@ using Runic
     include("utils/randpl.jl")
     include("utils/nfvar3_and_estimate.jl")
     include("utils/estimations.jl")
+    include("utils/modify.jl")
 
     # search_and_matching
     include("markets/search_and_matching.jl")

--- a/test/utils/modify.jl
+++ b/test/utils/modify.jl
@@ -1,0 +1,7 @@
+
+@testset "Retrieve/Add/Remove Agents" begin
+	parameters = Bit.AUSTRIA2010Q1.parameters
+    initial_conditions = Bit.AUSTRIA2010Q1.initial_conditions
+    model = Bit.Model(parameters, initial_conditions)
+    #...
+end


### PR DESCRIPTION
This is a way to fake object-oriented representation of agents, without impacting anything already available. Agents have ids and are retrieved/added/removed using that. Example:

```julia
julia> parameters = Bit.AUSTRIA2010Q1.parameters;

julia> initial_conditions = Bit.AUSTRIA2010Q1.initial_conditions;

julia> model = Bit.Model(parameters, initial_conditions);

julia> agent = model.w_act[1]
Worker(id = 1, Y_h = 0.7661282859097249, D_h = 3.781806633594487, K_h = 6.973481059156249, w_h = 0.2697101055708983, O_h = 1, C_d_h = 0.0, I_d_h = 0.0, C_h = 0.0, I_h = 0.0)

julia> agent.D_h
3.781806633594487

julia> agent.D_h = 1.0
1.0

julia> delete!(model.w_act, 1); # remove Worker Agent with id=1

julia> push!(model.w_act, (Y_h = 1.0, D_h = 1.0, K_h=1.0, w_h=1.0, O_h = 1.0, C_d_h = 1.0, I_d_h = 1.0, C_h = 1.0, I_h = 1.0)); # add a new worker
```

Still needs tests and docstrings.